### PR TITLE
Add install_successfull to manual install steps

### DIFF
--- a/README
+++ b/README
@@ -100,7 +100,10 @@ Sample installation tutorial when packages are downloaded
            (To figure out your perl version type in 'perl -v' and then change 5.x to your perl version)   
 
 
-2.f)      start a new shell session to apply changes to environment variables
+2.f)      cd to your mirdeep2 directory (the one containing install.pl)
+          touch install_successful
+
+2.g)      start a new shell session to apply changes to environment variables
 
 to test if everything is installed properly type in 
 1) bowtie


### PR DESCRIPTION
Version 0.0.8 introduced the creation of `install_successful` to `install.pl`
and checks therefor to the miRDeep2 scripts. Thus, the manual installation
instructions need updating, too, to ensure users following the Readme end up
with a working installation.