### PR TITLE
[RFC] Gracefully handle zero mapped reads

### DIFF
--- a/src/mapper.pl
+++ b/src/mapper.pl
@@ -715,7 +715,7 @@ sub read_stats{
 	}
 	close IN;
 	my %hash2;
-	my $count2;
+	my $count2 = 0;
 	my %k22;
 
 	print STDERR "Mapping statistics\n";

--- a/src/quantifier.pl
+++ b/src/quantifier.pl
@@ -441,7 +441,7 @@ sub read_stats{
 	}
 	close IN;
 	my %hash2;
-	my $count2;
+	my $count2 = 0;
 	my %k22;
 
 	print STDERR "Mapping statistics\n";


### PR DESCRIPTION
This silences 'Use of uninitialized value' errors when analyzing data with zero reads mapping to miRNAs (fixes https://github.com/rajewsky-lab/mirdeep2/issues/27).