### PR TITLE
install.pl: Fix Perl PDF::API2 installation

### DIFF
--- a/install.pl
+++ b/install.pl
@@ -634,7 +634,7 @@ if($ret == 0){
 	`$dtool http://www.cpan.org/authors/id/S/SS/SSIMMS/CHECKSUMS $dopt`;
 	open IN,"CHECKSUMS" or die "File checksums not found\n";
 	while(<IN>){
-		if(/((PDF-API2.+).tar.gz)/){
+		if(/((PDF-API2-\d.+).tar.gz)/){
 			$dfile=$1;
 			$version=$2;
 		}


### PR DESCRIPTION
The latest version of `PDF::API2` is determined from the CPAN `CHECKSUMS` file via a regular expression.
With the introduction of `PDF:API2::XS` this could results in installing it instead of `PDF:API2`, which was picked up by `install.pl` as an installation error of `PDF:API2`.
This is fixed by extending the regular expression used to match against the (beginning) of the version number and thus avoid the clash with `PDF:API2::XS`.

---
fixes #87